### PR TITLE
Remember the current state and push that on the undo stack when redoing

### DIFF
--- a/addon/undo-stack.js
+++ b/addon/undo-stack.js
@@ -45,6 +45,7 @@ export default Em.Mixin.create({
     if(checkpointData !== this.get('undoStack.lastObject')) {
       this.get('undoStack').pushObject(checkpointData);
       this.get('redoStack').clear();
+      this.set('_undoStackCurrent', checkpointData);
     }
 
     if(this.get('hasCheckpointsToRemove')) {
@@ -58,6 +59,7 @@ export default Em.Mixin.create({
 
       var last = this.get('undoStack').popObject();
       if(current !== last) {
+        this.set('_undoStackCurrent', last);
         this.restoreCheckpoint(last);
         this.get('redoStack').pushObject(current);
       } else {
@@ -68,7 +70,7 @@ export default Em.Mixin.create({
 
   redo: function() {
     if(this.get('canRedo')) {
-      var current = this.get('checkpointData');
+      var current = this.get('_undoStackCurrent');
       var last = this.get('redoStack').popObject();
       this.restoreCheckpoint(last);
       this.get('undoStack').pushObject(current);

--- a/tests/unit/undo-stack-test.js
+++ b/tests/unit/undo-stack-test.js
@@ -186,3 +186,16 @@ test('the undo stack has a maximum depth', function() {
   equal(cat.get('undoStackInfo'), 'undo: [0] redo: [3]');
   equal(cat.get('age'), 8);
 });
+
+test('modified objects do not get put on the undo stack when redoing', function() {
+  var cat = Cat.create({ name: 'Sully', age: 7 });
+
+  equal(cat.get('info'), 'Sully (7) has 0 kittens');
+  cat.checkpoint();
+  cat.set('name', 'Sooty');
+  cat.checkpoint();
+  cat.undo();
+  cat.set('name', 'Brian');
+  cat.redo();
+  equal(cat.get('info'), 'Sooty (7) has 0 kittens');
+});


### PR DESCRIPTION
We shouldn't push the current state onto the undo stack when redoing, we should remember the old state and push that on instead.