### PR TITLE
Remove unused dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
     "handlebars": "~1.3.0",
     "jquery": "^1.11.1",
     "ember": "1.7.0",
-    "ember-data": "1.0.0-beta.10",
     "ember-resolver": "~0.1.7",
     "loader.js": "stefanpenner/loader.js#1.0.1",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "ember-export-application-global": "^1.0.0",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.1.0",
-    "ember-data": "1.0.0-beta.10"
+    "ember-cli-qunit": "0.1.0"
   },
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "author": "Gavin Joyce",
   "license": "Apache",
   "devDependencies": {
-    "body-parser": "^1.2.0",
     "broccoli-asset-rev": "0.3.1",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "0.1.2",
@@ -26,9 +25,7 @@
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.1.0",
-    "ember-data": "1.0.0-beta.10",
-    "express": "^4.8.5",
-    "glob": "^4.0.5"
+    "ember-data": "1.0.0-beta.10"
   },
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Hey guys, just playing around with ember, and looks like this dependencies are not used here.

Also the latest minor release of glob 4.x.x (4.5.3) is failing for me:
```sh
ember server
version: 0.1.2
Livereload server on port 35729
Serving on http://0.0.0.0:4200/
Object function glob(pattern, options, cb) {
  if (typeof options === "function") cb = options, options = {}
  if (!options) options = {}

  if (typeof options === "number") {
    deprecated()
    return
  }

  var g = new Glob(pattern, options, cb)
  return g.sync ? g.found : g
} has no method 'hasMagic'
```