### PR TITLE
Undo after multiple redos doesn't work properly

### DIFF
--- a/addon/undo-stack.js
+++ b/addon/undo-stack.js
@@ -73,6 +73,7 @@ export default Em.Mixin.create({
       var current = this.get('_undoStackCurrent');
       var last = this.get('redoStack').popObject();
       this.restoreCheckpoint(last);
+      this.set('_undoStackCurrent', last);
       this.get('undoStack').pushObject(current);
     }
   }

--- a/tests/unit/undo-stack-test.js
+++ b/tests/unit/undo-stack-test.js
@@ -199,3 +199,26 @@ test('modified objects do not get put on the undo stack when redoing', function(
   cat.redo();
   equal(cat.get('info'), 'Sooty (7) has 0 kittens');
 });
+
+test('undo after redo works', function() {
+  var cat = Cat.create({ name: 'Sully', age: 7 });
+  cat.checkpoint();
+
+  equal(cat.get('info'), 'Sully (7) has 0 kittens');
+
+  cat.set('name', 'Sooty');
+  cat.checkpoint();
+  cat.set('name', 'Brian');
+  cat.checkpoint();
+  cat.set('name', 'Charlie');
+  cat.checkpoint();
+
+  cat.undo();
+  cat.undo();
+  equal(cat.get('info'), 'Sooty (7) has 0 kittens');
+  cat.redo();
+  cat.redo();
+  equal(cat.get('info'), 'Charlie (7) has 0 kittens');
+  cat.undo();
+  equal(cat.get('info'), 'Brian (7) has 0 kittens');
+});


### PR DESCRIPTION
Hey after playing around and learning ember I noticed one bug :)
Undo after multiple redos doesn't work. (I was able to reproduce it in composer as well)
This small change should fix it.

See demo:
![screen](https://cloud.githubusercontent.com/assets/1857751/6921654/1551d8ee-d7be-11e4-9264-c6f7b00f8535.gif)
)