### PR TITLE
Use the correct SPDX license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">= 0.10.0"
   },
   "author": "Gavin Joyce",
-  "license": "Apache",
+  "license": "Apache-2.0",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
     "ember-cli": "1.13.1",


### PR DESCRIPTION
Avoids the following npm warning 
```
npm WARN ember-undo-stack@0.4.0 license should be a valid SPDX license expression
```