### PR TITLE
Pin jQuery to 1.11.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "ember-qunit": "0.4.1",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.1",
+    "jquery": "1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1"
   }


### PR DESCRIPTION
Avoids ember-cli/ember-cli#5316 - there's more details [here](https://github.com/ember-cli/ember-cli/issues/5316) and a good description [here](http://benlimmer.com/2016/01/08/ember-jquery-dependancies/):

> Just recently, jQuery 1.12.x was released to bower, and Ember-CLI’s default blueprint allowed upgrading to this version. Unfortunately, all current versions of Ember have a hardcoded check that will make you have a bad time.

It was fixed in ember by https://github.com/emberjs/ember.js/pull/12793.

![image](https://cloud.githubusercontent.com/assets/401983/14799472/923106aa-0b34-11e6-8ad6-dd97ff68e121.png)
