### PR TITLE
Import throttle directly 

### DIFF
--- a/addon/undo-stack.js
+++ b/addon/undo-stack.js
@@ -3,7 +3,7 @@ import { A } from '@ember/array';
 import Mixin from '@ember/object/mixin';
 import { computed } from '@ember/object';
 import { on } from '@ember/object/evented';
-import { run, cancel } from '@ember/runloop';
+import { throttle, cancel } from '@ember/runloop';
 
 export default Mixin.create({
   undoCheckpointThrottleInMilliseconds: 800,
@@ -44,7 +44,7 @@ export default Mixin.create({
   hasCheckpointsToRemove: gt('checkpointsToRemoveCount', 0),
 
   throttledCheckpoint() {
-    this.set('undoStackThrottleTimer', run.throttle(this, this.checkpoint, this.get('undoCheckpointThrottleInMilliseconds'), true));
+    this.set('undoStackThrottleTimer', throttle(this, this.checkpoint, this.get('undoCheckpointThrottleInMilliseconds'), true));
   },
 
   checkpoint() {


### PR DESCRIPTION
Using `run.` to access runloop functions is deprecated. This PR imports throttle directly:

<img width="695" alt="Screenshot 2024-01-22 at 16 04 16" src="https://github.com/intercom/ember-undo-stack/assets/106588403/dbf988b9-3eb4-4d32-9053-8e350a954c13">

--- 

Ran `ember try` locally (on Node 12) and got the following - errors seem related to node version compatibility rather than my proposed changes. We should modernize this at some point. Running on master results in the same failures for select scenarios. 

```Scenario ember-lts-2.18: FAIL
Command run: ember test
with env: {
  "EMBER_OPTIONAL_FEATURES": "{\"jquery-integration\":true}"
}
Scenario ember-lts-3.4: SUCCESS
Command run: ember test
Scenario ember-release: FAIL
Command run: ember test
Scenario ember-beta: FAIL
Command run: ember test
Scenario ember-canary: FAIL
Command run: ember test
Scenario ember-default: SUCCESS
Command run: ember test
Scenario ember-default-with-jquery: SUCCESS
Command run: ember test
with env: {
  "EMBER_OPTIONAL_FEATURES": "{\"jquery-integration\":true}"
}

4 scenarios failed
3 scenarios succeeded
7 scenarios run
```
