### PR TITLE
Bump version to 1.0.3-staged-test.0 (staged-publishing experiment)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-undo-stack",
-  "version": "1.0.3",
+  "version": "1.0.3-staged-test.0",
   "description": "A simple undo/redo stack for Ember.js objects",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
### Why?

Exercise the OIDC + staged-publishing workflow (added in #61) end-to-end against this dormant package before recommending the pattern more widely. This disposable prerelease version is the one that gets staged during the experiment.

### How?

Bumps `package.json` to a throwaway prerelease, `1.0.3-staged-test.0`. `npm stage publish` packs the version from `package.json`, and the GitHub Release must be named `v1.0.3-staged-test.0` so the workflow's verify-job tag-vs-version assertion passes. Reverted once the experiment is complete.

<sub>Generated with Claude Code</sub>