### PR TITLE
NEGATIVE TEST (do not merge): verify should refuse a stable release off the default branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-undo-stack",
-  "version": "1.0.3",
+  "version": "99.99.99",
   "description": "A simple undo/redo stack for Ember.js objects",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
### Why?

Throwaway negative test for the staged-publishing workflow — **do not merge, do not review.** It validates that the publish workflow's verify job refuses a *stable* release cut from a commit that is **not reachable from the default branch** (a release-source guardrail in `publish.yml`).

### How?

Bumps the version to a synthetic `99.99.99` on this intentionally-unmerged branch; a stable release is then cut directly from the branch tip so the verify job's `git merge-base` source guard can reject it before anything reaches the registry. Kept unmerged on purpose — merging would make the commit reachable from the default branch and the guard would (correctly) allow it. Branch, PR, and release are all deleted after verification.

<sub>Generated with Claude Code</sub>