### PR TITLE
security: bump brace-expansion for GHSA-mh99-v99m-4gvg

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,9 +1791,9 @@ bower-endpoint-parser@0.2.2:
   integrity sha1-ALVlrb+rby01rd3pd+l5Yqy8s/Y=
 
 brace-expansion@^1.1.7:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
Bumps the transitive `brace-expansion` dependency out of the range flagged by
GHSA-mh99-v99m-4gvg (CVE-2026-14257, High).

`expand()` caps how many results it produces but not how long they get, so a
few KB of chained brace groups is enough to exhaust memory and kill the Node
process. The OOM is fatal, so wrapping the call in `try/catch` does not help.
Anything that feeds attacker-influenced strings into brace patterns through
`minimatch` or `glob` can be crashed this way.

Lockfile only. `brace-expansion` is not a direct dependency here, and
`minimatch` (the only consumer) declares a caret range that the new version
already satisfies, so no manifest needed changing.

The versions here are 1.1.18 / 2.1.4 / 5.0.9, not the 1.1.17 / 2.1.3 / 5.0.8
this advisory names. The higher set clears the other brace-expansion advisories
that are open at the same time, and the dependency set is unchanged within each
major line either way.

Worth knowing if you are still on Node 18: brace-expansion raised its engines
floor to `20 || >=22` in 5.0.8, so any fix in the 5.x line brings that with it.
It warns rather than fails unless you run engine-strict.

To check nothing else moved, I stripped every brace-expansion entry out of the
old and new lockfiles and confirmed the remainder was byte-identical, then ran a
frozen-lockfile install to verify the integrity hashes against the registry.
